### PR TITLE
move messages.properties into omod during packaging

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -70,7 +70,10 @@
 				<targetPath>web/module</targetPath>
 			</resource>
             <resource>
-                <directory>../api/src/main/resources/message.properties</directory>
+                <directory>../api/src/main/resources</directory>
+                <includes>
+                    <include>messages.properties</include>
+                </includes>
                 <filtering>true</filtering>
             </resource>
         </resources>


### PR DESCRIPTION
currently this modules fails to load when installed in openmrs 1.9.x
copying message.properties to omod during package to maintain compatibility with openmrs 1.9.x, as discussed here : https://issues.openmrs.org/browse/TRUNK-3889?focusedCommentId=209053&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-209053
