### PR TITLE
SXS-30 - Remove $HibernateProxy$ to avoid "Unable to de-serialize error"

### DIFF
--- a/api/src/main/java/org/openmrs/module/serialization/xstream/mapper/CGLibMapper.java
+++ b/api/src/main/java/org/openmrs/module/serialization/xstream/mapper/CGLibMapper.java
@@ -58,6 +58,13 @@ public class CGLibMapper extends MapperWrapper {
 			count -= 2;
 			return name.substring(0, count);
 		}
+		else {
+			count = name.indexOf("$HibernateProxy$");
+			if (count >= 0) {
+				return name.substring(0, count);
+			}
+		}
+		
 		return name;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/serialization/xstream/mapper/CGLibMapper.java
+++ b/api/src/main/java/org/openmrs/module/serialization/xstream/mapper/CGLibMapper.java
@@ -15,7 +15,7 @@ import com.thoughtworks.xstream.mapper.MapperWrapper;
 public class CGLibMapper extends MapperWrapper {
 	
 	public static final String marker = new String("EnhancerByCGLIB");
-	public static final String hibernateProxy = new String("$HibernateProxy$");
+	private static final String HIBERNATE_PROXY = "$HibernateProxy$";
 	
 	public CGLibMapper(Mapper wrapped) {
 		super(wrapped);
@@ -60,7 +60,7 @@ public class CGLibMapper extends MapperWrapper {
 			return name.substring(0, count);
 		}
 		else {
-			count = name.indexOf(hibernateProxy);
+			count = name.indexOf(HIBERNATE_PROXY);
 			if (count >= 0) {
 				return name.substring(0, count);
 			}

--- a/api/src/main/java/org/openmrs/module/serialization/xstream/mapper/CGLibMapper.java
+++ b/api/src/main/java/org/openmrs/module/serialization/xstream/mapper/CGLibMapper.java
@@ -15,6 +15,7 @@ import com.thoughtworks.xstream.mapper.MapperWrapper;
 public class CGLibMapper extends MapperWrapper {
 	
 	public static final String marker = new String("EnhancerByCGLIB");
+	public static final String hibernateProxy = new String("$HibernateProxy$");
 	
 	public CGLibMapper(Mapper wrapped) {
 		super(wrapped);
@@ -59,7 +60,7 @@ public class CGLibMapper extends MapperWrapper {
 			return name.substring(0, count);
 		}
 		else {
-			count = name.indexOf("$HibernateProxy$");
+			count = name.indexOf(hibernateProxy);
 			if (count >= 0) {
 				return name.substring(0, count);
 			}


### PR DESCRIPTION
Issue: Unable to de-serialize reports

This happens sporadically and seems to be connected to a "Hibernate proxy class name" inside the report definition.  

The suggestion is to remove "$HibernateProxy$" from the class name 